### PR TITLE
Fix several Terraform issues

### DIFF
--- a/edmm-core/src/main/java/io/github/edmm/core/BashScript.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/BashScript.java
@@ -29,14 +29,18 @@ public class BashScript {
     }
 
     private void init() {
-        logger.info("Creating bash script at '{}'", scriptPath);
-        fileAccess.delete(scriptPath);
         try {
-            fileAccess.append(scriptPath, SHEBANG);
-            fileAccess.append(scriptPath, IMMEDIATE_EXIT);
-        } catch (IOException e) {
-            logger.error("Failed to initialize bash script: {}", e.getMessage(), e);
-            throw new TransformationException(e);
+            fileAccess.getAbsolutePath(scriptPath);
+        } catch (FileNotFoundException fileException) {
+            // if the file doesn't exist, we create it
+            logger.info("Creating bash script at '{}'", scriptPath);
+            try {
+                fileAccess.append(scriptPath, SHEBANG);
+                fileAccess.append(scriptPath, IMMEDIATE_EXIT);
+            } catch (IOException e) {
+                logger.error("Failed to initialize bash script: {}", e.getMessage(), e);
+                throw new TransformationException(e);
+            }
         }
     }
 

--- a/edmm-core/src/main/java/io/github/edmm/core/transformation/TransformationContext.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/transformation/TransformationContext.java
@@ -121,6 +121,22 @@ public final class TransformationContext {
         return values.get(name);
     }
 
+    public void setErrorState(Exception e) {
+        this.state = State.ERROR;
+        this.putValue("exception",e);
+    }
+
+    /**
+     * This function will be called by Winery to re-throw the exception triggered during the
+     * transformation and inform the user about that.
+     */
+    public void throwExceptionIfErrorState() throws Exception {
+        Exception e = (Exception) this.getValue("exception");
+        if (this.state == State.ERROR &&  e != null) {
+            throw e;
+        }
+    }
+
     public enum State {
         READY,
         TRANSFORMING,

--- a/edmm-core/src/main/java/io/github/edmm/core/transformation/TransformationService.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/transformation/TransformationService.java
@@ -64,6 +64,7 @@ public class TransformationService {
                 executor.submit(new TransformationTask(plugin.get(), context)).get();
             } catch (Exception e) {
                 logger.error("Error executing transformation task", e);
+                context.setErrorState(e);
             }
         }
     }

--- a/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
@@ -1,6 +1,7 @@
 package io.github.edmm.core.transformation.support;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.Callable;
 
 import io.github.edmm.core.DeploymentTechnology;
@@ -8,6 +9,7 @@ import io.github.edmm.core.plugin.TransformationPlugin;
 import io.github.edmm.core.transformation.TransformationContext;
 
 import lombok.NonNull;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,14 @@ public final class TransformationTask implements Callable<Void> {
             logger.error("Could not create directory at '{}'", targetDirectory.getAbsolutePath());
             context.setState(ERROR);
             return null;
+        } else if (targetDirectory.exists()) {
+            try {
+                FileUtils.deleteDirectory(targetDirectory);
+                targetDirectory.mkdirs();
+                logger.info("{} directory overwritten", targetDirectory.getName());
+            } catch (IOException e) {
+                logger.warn("Could not overwrite {} directory, content will be appended to files", targetDirectory.getName());
+            }
         }
         if (!targetDirectory.isDirectory() || !targetDirectory.canWrite()) {
             logger.error("Given value is not a directory or not writable: {}", targetDirectory.getAbsolutePath());

--- a/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
@@ -43,7 +43,7 @@ public final class TransformationTask implements Callable<Void> {
                 logger.warn("Could not delete {} directory, content will be appended to files", targetDirectory.getName());
             }
         }
-        if (!targetDirectory.mkdirs()) {
+        if (!targetDirectory.exists() && !targetDirectory.mkdirs()) {
             logger.error("Could not create directory at '{}'", targetDirectory.getAbsolutePath());
             context.setState(ERROR);
             return null;

--- a/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
@@ -61,7 +61,7 @@ public final class TransformationTask implements Callable<Void> {
         } catch (Exception e) {
             logger.info("Transformation to {} failed", deploymentTechnology.getName());
             logger.error("Something went wrong while transforming", e);
-            context.setState(ERROR);
+            context.setErrorState(e);
         }
         return null;
     }

--- a/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/transformation/support/TransformationTask.java
@@ -35,19 +35,20 @@ public final class TransformationTask implements Callable<Void> {
         logger.info("Starting transformation for {}", deploymentTechnology.getName());
         context.setState(TRANSFORMING);
         File targetDirectory = context.getTargetDirectory();
-        if (!targetDirectory.exists() && !targetDirectory.mkdirs()) {
+        if (targetDirectory.exists()) {
+            try {
+                FileUtils.deleteDirectory(targetDirectory);
+                logger.info("{} directory will be overwritten", targetDirectory.getName());
+            } catch (IOException e) {
+                logger.warn("Could not delete {} directory, content will be appended to files", targetDirectory.getName());
+            }
+        }
+        if (!targetDirectory.mkdirs()) {
             logger.error("Could not create directory at '{}'", targetDirectory.getAbsolutePath());
             context.setState(ERROR);
             return null;
-        } else if (targetDirectory.exists()) {
-            try {
-                FileUtils.deleteDirectory(targetDirectory);
-                targetDirectory.mkdirs();
-                logger.info("{} directory overwritten", targetDirectory.getName());
-            } catch (IOException e) {
-                logger.warn("Could not overwrite {} directory, content will be appended to files", targetDirectory.getName());
-            }
         }
+
         if (!targetDirectory.isDirectory() || !targetDirectory.canWrite()) {
             logger.error("Given value is not a directory or not writable: {}", targetDirectory.getAbsolutePath());
             context.setState(ERROR);

--- a/edmm-core/src/main/java/io/github/edmm/plugins/terraform/aws/TerraformAwsVisitor.java
+++ b/edmm-core/src/main/java/io/github/edmm/plugins/terraform/aws/TerraformAwsVisitor.java
@@ -74,7 +74,6 @@ public class TerraformAwsVisitor extends TerraformVisitor {
             logger.error("Failed to write Terraform file", e);
             throw new TransformationException(e);
         }
-        BashScript envScript = new BashScript(fileAccess, "env.sh");
         for (Aws.Instance awsInstance : computeInstances.values()) {
             // Copy artifacts to target directory
             for (FileProvisioner provisioner : awsInstance.getFileProvisioners()) {
@@ -97,6 +96,7 @@ public class TerraformAwsVisitor extends TerraformVisitor {
                 }
             }
             // Write env.sh script entries
+            BashScript envScript = new BashScript(fileAccess, "env.sh");
             awsInstance.getEnvVars().forEach((name, value) -> envScript.append("export " + name + "=" + value));
         }
     }

--- a/edmm-core/src/main/java/io/github/edmm/plugins/terraform/aws/TerraformAwsVisitor.java
+++ b/edmm-core/src/main/java/io/github/edmm/plugins/terraform/aws/TerraformAwsVisitor.java
@@ -74,6 +74,7 @@ public class TerraformAwsVisitor extends TerraformVisitor {
             logger.error("Failed to write Terraform file", e);
             throw new TransformationException(e);
         }
+        BashScript envScript = new BashScript(fileAccess, "env.sh");
         for (Aws.Instance awsInstance : computeInstances.values()) {
             // Copy artifacts to target directory
             for (FileProvisioner provisioner : awsInstance.getFileProvisioners()) {
@@ -96,7 +97,6 @@ public class TerraformAwsVisitor extends TerraformVisitor {
                 }
             }
             // Write env.sh script entries
-            BashScript envScript = new BashScript(fileAccess, "env.sh");
             awsInstance.getEnvVars().forEach((name, value) -> envScript.append("export " + name + "=" + value));
         }
     }

--- a/edmm-core/src/main/java/io/github/edmm/plugins/terraform/aws/TerraformAwsVisitor.java
+++ b/edmm-core/src/main/java/io/github/edmm/plugins/terraform/aws/TerraformAwsVisitor.java
@@ -270,7 +270,9 @@ public class TerraformAwsVisitor extends TerraformVisitor {
                 beanstalk.setName(component.getNormalizedName());
                 component.getArtifacts().stream().findFirst().ifPresent(artifact -> {
                     File file = new File(artifact.getValue());
-                    Path resolvedFile = context.getSourceDirectory().toPath().resolve(file.toPath()).normalize();
+                    Path resolvedFile = (context.getSourceDirectory() != null) ?
+                                context.getSourceDirectory().toPath().resolve(file.toPath()).normalize() :
+                                file.toPath().normalize();
                     beanstalk.setFilepath(resolvedFile.getParent().toString().replace("\\", "\\\\"));
                     beanstalk.setFilename(file.getName());
                 });

--- a/edmm-core/src/main/java/io/github/edmm/plugins/terraform/model/Aws.java
+++ b/edmm-core/src/main/java/io/github/edmm/plugins/terraform/model/Aws.java
@@ -20,9 +20,7 @@ public class Aws {
         private String filename;
 
         public void setFilepath(String filepath) {
-            this.filepath = filepath != null && filepath.endsWith(Consts.FS)
-                ? filepath
-                : Consts.FS.endsWith("\\") ? filepath + Consts.FS + Consts.FS : filepath + Consts.FS;
+            this.filepath = Aws.setFilePath(filepath);
         }
     }
 
@@ -35,6 +33,19 @@ public class Aws {
         private String instanceClass = "db.t2.micro";
         private String username = "user";
         private String password = "password";
+
+        private String schemaPath = "./";
+        private String configurePath = "./";
+
+        public void setSchemaPath(String filepath, String filename) {
+            this.schemaPath = Aws.setFilePath(filepath);
+            this.schemaPath += filename;
+        }
+
+        public void setConfigurePath(String filepath, String filename) {
+            this.configurePath = Aws.setFilePath(filepath);
+            this.configurePath += filename;
+        }
     }
 
     @Data
@@ -75,5 +86,11 @@ public class Aws {
         public void addEnvVar(String name, String value) {
             envVars.put(name, value);
         }
+    }
+
+    private static String setFilePath(String filepath) {
+        return filepath != null && filepath.endsWith(Consts.FS)
+            ? filepath
+            : Consts.FS.endsWith("\\") ? filepath + Consts.FS + Consts.FS : filepath + Consts.FS;
     }
 }

--- a/edmm-core/src/main/resources/plugins/terraform/aws.tf
+++ b/edmm-core/src/main/resources/plugins/terraform/aws.tf
@@ -161,6 +161,22 @@ resource "aws_db_instance" "${db.name}" {
   parameter_group_name = "edmm.mysql5.7"
 }
 
+resource "null_resource" "db_setup" {
+
+  depends_on = ["aws_db_instance.${db.name}"]
+
+    provisioner "local-exec" {
+        command = "${db.configurePath}"
+        environment {
+          MYSQL_SCHEMA_PATH = "${db.schemaPath}"
+          MYSQL_DBMS_ENDPOINT = aws_db_instance.${db.name}.endpoint
+          MYSQL_DBMS_PORT = aws_db_instance.${db.name}.port
+          MYSQL_DATABASE_USER = aws_db_instance.${db.name}.username
+          MYSQL_DBMS_ROOT_PASSWORD = aws_db_instance.${db.name}.password
+        }
+    }
+}
+
 </#list>
 </#if>
 </#if>

--- a/edmm-core/src/main/resources/plugins/terraform/aws.tf
+++ b/edmm-core/src/main/resources/plugins/terraform/aws.tf
@@ -163,18 +163,18 @@ resource "aws_db_instance" "${db.name}" {
 
 resource "null_resource" "db_setup" {
 
-  depends_on = ["aws_db_instance.${db.name}"]
+    depends_on = ["aws_db_instance.${db.name}"]
 
-    provisioner "local-exec" {
-        command = "${db.configurePath}"
+    provisioner "remote-exec" {
+        scripts = ["${db.configurePath}"]
         environment {
-          MYSQL_SCHEMA_PATH = "${db.schemaPath}"
-          MYSQL_DBMS_ENDPOINT = aws_db_instance.${db.name}.endpoint
-          MYSQL_DBMS_PORT = aws_db_instance.${db.name}.port
-          MYSQL_DATABASE_USER = aws_db_instance.${db.name}.username
-          MYSQL_DBMS_ROOT_PASSWORD = aws_db_instance.${db.name}.password
+            MYSQL_SCHEMA_PATH = "${db.schemaPath}"
+            MYSQL_DBMS_ENDPOINT = aws_db_instance.${db.name}.endpoint
+            MYSQL_DBMS_PORT = aws_db_instance.${db.name}.port
+            MYSQL_DATABASE_USER = aws_db_instance.${db.name}.username
+            MYSQL_DBMS_ROOT_PASSWORD = aws_db_instance.${db.name}.password
         }
-    }
+   }
 }
 
 </#list>


### PR DESCRIPTION
Solved some issues:
1) if there were more Compute nodes, the `env.sh` file got overwrited; now just one `env.sh` file is created with all the necessary variables
2) there was a `NullPointerException` when trying to access the `contex.sourceDirectory` in the `TerraformAwsVisitor.visit( WebApplication)` function
3) when creating `AwsAurora` we consider also the `schema.sql` and `configure.sh` files, that are invoked by a terraform `null_resource`
4) the `schema.sql`, `petclininc.war` and database `configure.sh` files are moved to the terraform generated directory
5) solved the terraform opened issue (it's fixed for all the plugins): the generated directory is simply recreated every time the CLI `transform` command is executed.
6) added a way to inform the Winery user in case the transformation raises an exception