### PR TITLE
Fix relation normalization

### DIFF
--- a/edmm-core/src/main/java/io/github/edmm/core/parser/EntityGraph.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/parser/EntityGraph.java
@@ -133,9 +133,7 @@ public class EntityGraph extends SimpleDirectedGraph<Entity, EntityGraph.Edge> {
                 } else {
                     childName = String.valueOf(i);
                 }
-                EntityId entryId = id.extend(String.valueOf(i));
-                addEntity(new MappingEntity(entryId, this));
-                EntityId childId = entryId.extend(childName);
+                EntityId childId = id.extend(childName);
                 populateGraph(childNode, childId);
             }
         } else if (node instanceof ScalarNode) {

--- a/edmm-core/src/main/java/io/github/edmm/core/parser/ScalarEntity.java
+++ b/edmm-core/src/main/java/io/github/edmm/core/parser/ScalarEntity.java
@@ -16,4 +16,12 @@ public class ScalarEntity extends Entity {
     public String toString() {
         return String.format("ScalarEntity (id='%s', value='%s')", getId(), getValue());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ScalarEntity entity = (ScalarEntity) o;
+        return super.equals(o) && this.value.equals(entity.value);
+    }
 }

--- a/edmm-core/src/test/java/io/github/edmm/model/DeploymentModelTest.java
+++ b/edmm-core/src/test/java/io/github/edmm/model/DeploymentModelTest.java
@@ -89,8 +89,10 @@ public class DeploymentModelTest {
         DeploymentModel model = DeploymentModel.of(resource.getFile());
         SoftwareComponent tomcat = (SoftwareComponent) model.getComponent("tomcat").orElseThrow(IllegalStateException::new);
         assertEquals(3, tomcat.getRelations().size());
-        assertEquals("hosted_on", tomcat.getRelations().get(1).getName());
-        RootRelation relation = tomcat.getRelations().get(0);
+        assertEquals("depends_on", tomcat.getRelations().get(0).getName());
+        assertEquals("depends_on", tomcat.getRelations().get(1).getName());
+        assertEquals("hosted_on", tomcat.getRelations().get(2).getName());
+        RootRelation relation = tomcat.getRelations().get(1);
         assertTrue(relation instanceof DependsOn);
         assertEquals("db", relation.getTarget());
         assertEquals(0, relation.getProperties().size());

--- a/edmm-core/src/test/resources/templates/scenario_paas_saas.yml
+++ b/edmm-core/src/test/resources/templates/scenario_paas_saas.yml
@@ -11,12 +11,8 @@ components:
       - war: ./files/app.war
     relations:
       - hosted_on: pet_clinic_platform
-      - connects_to_db:
-          type: connects_to
-          target: db
-      - connects_to_auth:
-          type: connects_to
-          target: auth
+      - connects_to: db
+      - connects_to: auth
 
   pet_clinic_platform:
     type: aws_beanstalk

--- a/edmm-core/src/test/resources/templates/unit-tests/relations_generated.yml
+++ b/edmm-core/src/test/resources/templates/unit-tests/relations_generated.yml
@@ -5,17 +5,17 @@ components:
   tomcat:
     relations:
     - '2':
-        depends_on:
-          type: depends_on
-          target: ubuntu
-    - '0':
         hosted_on:
           type: hosted_on
           target: ubuntu
-    - '1':
+    - '0':
         depends_on:
           type: depends_on
           target: db
+    - '1':
+        depends_on:
+          type: depends_on
+          target: ubuntu
     type: software_component
   db:
     type: software_component


### PR DESCRIPTION
Adding this should solve the problem of having same relation types also in the Winery `EdmmConverter`. 
At the moment Winaery is not able to produce a yaml where a component has two relations with the same type, but different target.